### PR TITLE
Feature opentype

### DIFF
--- a/src/main/scala/com/repocad/web/util/opentype/Font.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/Font.scala
@@ -4,8 +4,27 @@ import org.scalajs.dom.raw.CanvasRenderingContext2D
 
 import scala.scalajs.js
 
+trait Font {
+
+  val ascender: Double
+
+  val descender: Double
+
+  def draw(context: CanvasRenderingContext2D, line: String, i: Int, yOffset: Double,
+           scale: Double, options: Map[String, String]): Unit
+
+  def getKerningValue(first: Glyph, second: Glyph): Double
+
+  def getPath(text: String, x: Double, y: Double, fontSize: Double): Path
+
+  def stringToGlyphs(string: String): Array[Glyph]
+
+  def unitsPerEm: Double
+
+}
+
 @js.native
-trait Font extends js.Object {
+trait OpentypeFont extends js.Object {
 
   val ascender: Double
 
@@ -13,13 +32,12 @@ trait Font extends js.Object {
 
   def draw(context: CanvasRenderingContext2D, line: String, i: Int, yOffset: Double, scale: Double, options: js.Dynamic): Unit
 
-  def getKerningValue(first: Glyph, second: Glyph): Double
+  def getKerningValue(first: OpentypeGlyph, second: OpentypeGlyph): Double
 
-  def getPath(text: String, x: Double, y: Double, fontSize: Double): Path
+  def getPath(text: String, x: Double, y: Double, fontSize: Double): OpentypePath
 
   def stringToGlyphs(string: String): js.Array[Glyph]
 
   def unitsPerEm: Double
 
 }
-

--- a/src/main/scala/com/repocad/web/util/opentype/Font.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/Font.scala
@@ -17,7 +17,7 @@ trait Font {
 
   def getPath(text: String, x: Double, y: Double, fontSize: Double): Path
 
-  def stringToGlyphs(string: String): Array[Glyph]
+  def stringToGlyphs(string: String): Seq[Glyph]
 
   def unitsPerEm: Double
 

--- a/src/main/scala/com/repocad/web/util/opentype/Font.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/Font.scala
@@ -36,7 +36,7 @@ trait OpentypeFont extends js.Object {
 
   def getPath(text: String, x: Double, y: Double, fontSize: Double): OpentypePath
 
-  def stringToGlyphs(string: String): js.Array[Glyph]
+  def stringToGlyphs(string: String): js.Array[OpentypeGlyph]
 
   def unitsPerEm: Double
 

--- a/src/main/scala/com/repocad/web/util/opentype/Glyph.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/Glyph.scala
@@ -10,9 +10,9 @@ trait Glyph {
   val yMin: Double
   val yMax: Double
 
-  def height = xMax - xMin
+  def height = yMax - yMin
 
-  def width = yMax - yMin
+  def width = xMax - xMin
 
 }
 

--- a/src/main/scala/com/repocad/web/util/opentype/Glyph.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/Glyph.scala
@@ -2,8 +2,7 @@ package com.repocad.web.util.opentype
 
 import scala.scalajs.js
 
-@js.native
-trait Glyph extends js.Object {
+trait Glyph {
 
   val advanceWidth: Double
   val xMin: Double
@@ -11,6 +10,20 @@ trait Glyph extends js.Object {
   val yMin: Double
   val yMax: Double
 
-  def font: Font
+  def height = xMax - xMin
 
+  def width = yMax - yMin
+
+}
+
+@js.native
+trait OpentypeGlyph extends js.Object {
+
+  val advanceWidth: Double
+  val xMin: Double
+  val xMax: Double
+  val yMin: Double
+  val yMax: Double
+
+  def font: OpentypeFont
 }

--- a/src/main/scala/com/repocad/web/util/opentype/Path.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/Path.scala
@@ -4,8 +4,18 @@ import org.scalajs.dom.raw.CanvasRenderingContext2D
 
 import scala.scalajs.js
 
+trait Path {
+
+  var fill: String = ""
+
+  def draw(context: CanvasRenderingContext2D): Unit
+
+  def toSVG(decimalPlaces: Double): String
+
+}
+
 @js.native
-trait Path extends js.Object {
+trait OpentypePath extends js.Object {
 
   var fill: String = js.native
 

--- a/src/main/scala/com/repocad/web/util/opentype/package.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/package.scala
@@ -23,7 +23,8 @@ package object opentype {
         opentypeFont.draw(context, line, i, yOffset, scale, jsObject)
       }
 
-      override def stringToGlyphs(string: String): Seq[Glyph] = opentypeFont.stringToGlyphs(string).toSeq
+      override def stringToGlyphs(string: String): Seq[Glyph] =
+        opentypeFont.stringToGlyphs(string).map(opentypeGlyph2Glyph).toSeq
 
       override def getKerningValue(first: Glyph, second: Glyph): Double =
         opentypeFont.getKerningValue(first, second)

--- a/src/main/scala/com/repocad/web/util/opentype/package.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/package.scala
@@ -1,0 +1,66 @@
+package com.repocad.web.util
+
+import org.scalajs.dom.raw.CanvasRenderingContext2D
+
+import scala.scalajs.js
+
+/**
+  * Implicit helper functions for opentype conversion back and forth from JavaScript.
+  */
+package object opentype {
+
+  implicit def opentypeFont2Font(opentypeFont: OpentypeFont): Font = {
+    new Font {
+      override def unitsPerEm: Double = opentypeFont.unitsPerEm
+
+      override def draw(context: CanvasRenderingContext2D, line: String, i: Int,
+                        yOffset: Double, scale: Double, options: Map[String, String]): Unit = {
+        val jsObject = js.Dynamic.literal()
+        for ((k, v) <- options) {
+          jsObject.updateDynamic(k)(v)
+        }
+        opentypeFont.draw(context, line, i, yOffset, scale, jsObject)
+      }
+
+      override def stringToGlyphs(string: String): Array[Glyph] = opentypeFont.stringToGlyphs(string).toArray
+
+      override def getKerningValue(first: Glyph, second: Glyph): Double =
+        opentypeFont.getKerningValue(first, second)
+
+      override def getPath(text: String, x: Double, y: Double, fontSize: Double): Path =
+        opentypeFont.getPath(text, x, y, fontSize)
+
+      override val ascender: Double = opentypeFont.ascender
+      override val descender: Double = opentypeFont.descender
+    }
+  }
+
+  implicit def opentypeGlyph2Glyph(opentypeGlyph: OpentypeGlyph): Glyph = {
+    new Glyph {
+      override val advanceWidth: Double = opentypeGlyph.advanceWidth
+
+      override val yMin: Double = opentypeGlyph.yMin
+      override val xMax: Double = opentypeGlyph.xMax
+      override val xMin: Double = opentypeGlyph.xMin
+      override val yMax: Double = opentypeGlyph.yMax
+    }
+  }
+
+  implicit def glyph2OpentypeGlyph(glyph: Glyph): OpentypeGlyph = {
+    js.Dynamic.literal(
+      advanceWidth = glyph.advanceWidth,
+      yMin = glyph.yMin,
+      yMax = glyph.yMax,
+      xMin = glyph.xMin,
+      xMax = glyph.xMax).asInstanceOf[OpentypeGlyph]
+  }
+
+  implicit def opentypePath2Path(opentypePath: OpentypePath): Path = {
+    new Path {
+      override def draw(context: CanvasRenderingContext2D): Unit = opentypePath.draw(context)
+
+      override def toSVG(decimalPlaces: Double): String = opentypePath.toSVG(decimalPlaces)
+    }
+  }
+
+}

--- a/src/main/scala/com/repocad/web/util/opentype/package.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/package.scala
@@ -23,7 +23,7 @@ package object opentype {
         opentypeFont.draw(context, line, i, yOffset, scale, jsObject)
       }
 
-      override def stringToGlyphs(string: String): Array[Glyph] = opentypeFont.stringToGlyphs(string).toArray
+      override def stringToGlyphs(string: String): Seq[Glyph] = opentypeFont.stringToGlyphs(string).toSeq
 
       override def getKerningValue(first: Glyph, second: Glyph): Double =
         opentypeFont.getKerningValue(first, second)

--- a/src/main/scala/com/repocad/web/util/opentype/package.scala
+++ b/src/main/scala/com/repocad/web/util/opentype/package.scala
@@ -2,6 +2,7 @@ package com.repocad.web.util
 
 import org.scalajs.dom.raw.CanvasRenderingContext2D
 
+import scala.language.implicitConversions
 import scala.scalajs.js
 
 /**


### PR DESCRIPTION
Decoupling of the font-API (Font, Glyph, Path) from the scala-js specific opentype interfaces. In the longer run these interfaces could be used by other libraries than opentype.
I also wrote some implicit conversions to make it less painfull to work with.
